### PR TITLE
Use the slim version of Python as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:slim
 
 RUN mkdir /usr/src/whereisit
 COPY setup.py /usr/src/whereisit

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ with open(os.path.join(os.path.dirname(__file__), "whereisit", "__version__.py")
 install_requires = [
     "aiohttp",
     "uvloop",
-    "aiodns",
     "cchardet",
     "toml",
 ]


### PR DESCRIPTION
We had to remove aiodns because one if it's dependencies, pycares, doesn't have
a wheel