### PR TITLE
f all the strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ with open(os.path.join(os.path.dirname(__file__), "whereisit", "__version__.py")
 install_requires = [
     "aiohttp",
     "uvloop",
-    "cchardet",
     "toml",
 ]
 

--- a/whereisit/exceptions.py
+++ b/whereisit/exceptions.py
@@ -1,5 +1,5 @@
 class PostOfficeError(Exception):
     def __init__(self, tracking, json):
-        super().__init__('{}: {}'.format(tracking, json))
+        super().__init__(f'{tracking}: {json}')
         self.tracking = tracking
         self.json = json

--- a/whereisit/mailgun.py
+++ b/whereisit/mailgun.py
@@ -10,7 +10,7 @@ class Mailgun:
 
     async def send(self, *, from_addr, to_addrs, subject, body):
         request = self._session.post(
-            "https://api.mailgun.net/v3/{}/messages".format(urllib.parse.quote(self._domain)),
+            f'https://api.mailgun.net/v3/{self._domain}/messages',
             auth=aiohttp.BasicAuth("api", self._api_key),
             data={"from": from_addr,
                   "to": to_addrs,


### PR DESCRIPTION
Use the new string formatting whenever possible. There's no cchardet wheel for
Python 3.6 yet, and we wish to retain the use of the slim version of the docker
image, so we'll remove cchardet for the time.